### PR TITLE
Fix getMonday returning wrong date

### DIFF
--- a/src/utils/date-utils.ts
+++ b/src/utils/date-utils.ts
@@ -235,11 +235,11 @@ export function formatISOTime(date: Date | undefined): string {
  * @returns {string}
  */
 export function getMonday(date: Date): Date {
-	const newDate = new Date(date)
-	const day = newDate.getDay()
-	newDate.setHours(0, 0, 0, 0)
-	newDate.setDate(newDate.getDate() - day + (day === 0 ? -6 : 1))
-	return date
+        const newDate = new Date(date)
+        const day = newDate.getDay()
+        newDate.setHours(0, 0, 0, 0)
+        newDate.setDate(newDate.getDate() - day + (day === 0 ? -6 : 1))
+        return newDate
 }
 
 /**


### PR DESCRIPTION
## Summary
- return `newDate` from `getMonday` so weekday adjustment works

## Testing
- `bun tsc --noEmit` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6853143d6b148324a9e697a0c6bde32d